### PR TITLE
Fix up search ontology

### DIFF
--- a/src/search-context.json
+++ b/src/search-context.json
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@vocab": "http://bibsysdev.github.io/src/search-ontology#",
+    "hits": {
+      "@id": "hit",
+      "@container": "@set"
+    },
+    "contributor": {
+      "@container": "@set"
+    },
+    "createdDate": {
+      "@type": "xsd:dateTime"
+    },
+    "modifiedDate": {
+      "@type": "xsd:dateTime"
+    }
+  },
+  "hits": {
+    "@embed": "@always"
+  },
+  "contributor": {
+    "@embed": "@always"
+  }
+}

--- a/src/search-ontology.ttl
+++ b/src/search-ontology.ttl
@@ -28,3 +28,8 @@
 :nextResults a rdf:Property ;
   rdfs:domain :ResultSet ;
   rdfs:comment "The URI that can be used to get the next part of the Result set" .
+
+:processingTime a rdf:Property ;
+  rdfs:domain :ResultSet ;
+  rdfs:range xsd:integer ;
+  rdfs:comment "The number of milliseconds taken to process the request" .

--- a/src/search-ontology.ttl
+++ b/src/search-ontology.ttl
@@ -1,0 +1,30 @@
+@prefix : <http://bibsysdev.github.io/src/search-ontology#> .
+@prefix nva: <http://bibsysdev.github.io/src/nva> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:ResultSet a rdfs:Class ;
+  owl:sameAs schema:SearchResultsPage ;
+  rdfs:comment "A list of results for a given search" .
+
+:size a rdf:Property ;
+  rdfs:domain :ResultSet ;
+  rdfs:range xsd:nonNegativeInteger ;
+  rdfs:comment "The size of the results list" .
+
+:searchString a rdf:Property ;
+  rdfs:domain :ResultSet ;
+  rdfs:range xsd:string ;
+  rdfs:comment "The search string that generated the Result set" .
+
+:hits a rdf:Property ;
+  rdfs:domain :ResultSet ;
+  rdfs:range :Publication ;
+  rdfs:comment "A result returned from the Result set" .
+
+:nextResults a rdf:Property ;
+  rdfs:domain :ResultSet ;
+  rdfs:comment "The URI that can be used to get the next part of the Result set" .

--- a/src/search-ontology.ttl
+++ b/src/search-ontology.ttl
@@ -20,7 +20,7 @@
   rdfs:range xsd:string ;
   rdfs:comment "The search string that generated the Result set" .
 
-:hits a rdf:Property ;
+:hit a rdf:Property ;
   rdfs:domain :ResultSet ;
   rdfs:range :Publication ;
   rdfs:comment "A result returned from the Result set" .


### PR DESCRIPTION
Fixed the search ontology and added the json-ld context

- We likely lack the complete record returned by the search API as this has moved on since we first looked at this.
- There are unused namespaces in the ontology, will remove these when we know what is needed as regards the point above
